### PR TITLE
test-kitchen configuration update

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,8 @@
 ---
 driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
-  log_file: /var/log/chef-solo.log
+
+provisioner:
+  name: chef_solo
 
 platforms:
 - name: rightimage-ubuntu-12.04
@@ -34,3 +34,6 @@ suites:
 - name: default
   run_list: ["recipe[fake]"]
   attributes: {}
+  provisioner:
+    solo_rb:
+      log_location: /var/log/chef-solo.log

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'thor-foodcritic'
 gem 'thor-scmversion'
 
 group :integration do
-  gem 'test-kitchen', '~> 1.0.0.beta.3'
+  gem 'test-kitchen', '~> 1.1.1'
   gem 'kitchen-vagrant'
   gem 'strainer', '~> 3.3.0'
   gem 'chefspec', '~> 1.3.0'


### PR DESCRIPTION
test-kitchen configuration should be updated to use the new log_location format for the chef-solo log file.
